### PR TITLE
Make sure we only remove view title from the directive that set it

### DIFF
--- a/angularjs-viewhead.js
+++ b/angularjs-viewhead.js
@@ -1,9 +1,14 @@
 (function (angular) {
+    'use strict';
+
     var mod = angular.module('viewhead', []);
 
-    var title;
+    // Data service that is shared between all directives
+    mod.factory('viewTitleDataService', function () {
+        return {};
+    });
 
-    mod.directive('viewTitle', ['$rootScope', '$timeout', function ($rootScope, $timeout) {
+    mod.directive('viewTitle', ['$rootScope', 'viewTitleDataService', function ($rootScope, viewTitleDataService) {
         return {
             restrict: 'EA',
             link: function (scope, iElement) {
@@ -19,19 +24,18 @@
                 scope.$watch(function () {
                     return iElement.text();
                 }, function (newTitle) {
-                    $rootScope.viewTitle = title = newTitle;
+                    viewTitleDataService.id = scope.$id;
+
+                    $rootScope.viewTitle = newTitle;
                 });
 
                 scope.$on('$destroy', function () {
-                    title = undefined;
+                    // Only remove view title if the current title has been set by this scope
+                    if (viewTitleDataService.id === scope.$id) {
+                        delete $rootScope.viewTitle;
 
-                    // Wait until next digest cycle do delete viewTitle
-                    $timeout(function () {
-                        if (!title) {
-                            // No other view-title has reassigned title.
-                            delete $rootScope.viewTitle;
-                        }
-                    });
+                        delete viewTitleDataService.id;
+                    }
                 });
             }
         };

--- a/angularjs-viewhead.js
+++ b/angularjs-viewhead.js
@@ -1,76 +1,62 @@
-
 (function (angular) {
+    var mod = angular.module('viewhead', []);
 
-     var mod = angular.module('viewhead', []);
+    var title;
 
-     var title;
+    mod.directive('viewTitle', ['$rootScope', '$timeout', function ($rootScope, $timeout) {
+        return {
+            restrict: 'EA',
+            link: function (scope, iElement) {
+                // If we've been inserted as an element then we detach from the DOM because the caller
+                // doesn't want us to have any visual impact in the document.
+                // Otherwise, we're piggy-backing on an existing element so we'll just leave it alone.
+                var tagName = iElement[0].tagName.toLowerCase();
 
-     mod.directive(
-         'viewTitle',
-         ['$rootScope', '$timeout', function ($rootScope, $timeout) {
-             return {
-                 restrict: 'EA',
-                 link: function (scope, iElement, iAttrs, controller, transcludeFn) {
-                     // If we've been inserted as an element then we detach from the DOM because the caller
-                     // doesn't want us to have any visual impact in the document.
-                     // Otherwise, we're piggy-backing on an existing element so we'll just leave it alone.
-                     var tagName = iElement[0].tagName.toLowerCase();
-                     if (tagName === 'view-title' || tagName === 'viewtitle') {
-                         iElement.remove();
-                     }
+                if (tagName === 'view-title' || tagName === 'viewtitle') {
+                    iElement.remove();
+                }
 
-                     scope.$watch(
-                         function () {
-                             return iElement.text();
-                         },
-                         function (newTitle) {
-                             $rootScope.viewTitle = title = newTitle;
-                         }
-                     );
-                     scope.$on(
-                         '$destroy',
-                         function () {
-                             title = undefined;
-                             // Wait until next digest cycle do delete viewTitle
-                             $timeout(function() {
-                                 if(!title) {
-                                     // No other view-title has reassigned title.
-                                     delete $rootScope.viewTitle;
-                                 }
-                             });
-                         }
-                     );
-                 }
-             };
-         }]
-     );
+                scope.$watch(function () {
+                    return iElement.text();
+                }, function (newTitle) {
+                    $rootScope.viewTitle = title = newTitle;
+                });
 
-     mod.directive(
-         'viewHead',
-         ['$document', function ($document) {
-             var head = angular.element($document[0].head);
-             return {
-                 restrict: 'A',
-                 link: function (scope, iElement, iAttrs, controller, transcludeFn) {
-                     // Move the element into the head of the document.
-                     // Although the physical location of the document changes, the element remains
-                     // bound to the scope in which it was declared, so it can refer to variables from
-                     // the view scope if necessary.
-                     head.append(iElement);
+                scope.$on('$destroy', function () {
+                    title = undefined;
 
-                     // When the scope is destroyed, remove the element.
-                     // This is on the assumption that we're being used in some sort of view scope.
-                     // It doesn't make sense to use this directive outside of the view, and nor does it
-                     // make sense to use it inside other scope-creating directives like ng-repeat.
-                     scope.$on(
-                         '$destroy',
-                         function () {
-                             iElement.remove();
-                         }
-                     );
-                 }
-             };
-         }]
-     );
+                    // Wait until next digest cycle do delete viewTitle
+                    $timeout(function () {
+                        if (!title) {
+                            // No other view-title has reassigned title.
+                            delete $rootScope.viewTitle;
+                        }
+                    });
+                });
+            }
+        };
+    }]);
 
+    mod.directive('viewHead', ['$document', function ($document) {
+        var head = angular.element($document[0].head);
+
+        return {
+            restrict: 'A',
+            link: function (scope, iElement) {
+                // Move the element into the head of the document.
+                // Although the physical location of the document changes, the element remains
+                // bound to the scope in which it was declared, so it can refer to variables from
+                // the view scope if necessary.
+                head.append(iElement);
+
+                // When the scope is destroyed, remove the element.
+                // This is on the assumption that we're being used in some sort of view scope.
+                // It doesn't make sense to use this directive outside of the view, and nor does it
+                // make sense to use it inside other scope-creating directives like ng-repeat.
+                scope.$on('$destroy', function () {
+                    iElement.remove();
+                });
+            }
+        };
+    }]);
 })(angular);


### PR DESCRIPTION
When doing a page change in `ui-router`, the `scope.on('$destroy')` is called after the new view title directive has been initialized, resulting that there is no view title present.
