### PR TITLE
Prevent removing title if it changed

### DIFF
--- a/angularjs-viewhead.js
+++ b/angularjs-viewhead.js
@@ -4,6 +4,7 @@
      var mod = angular.module('viewhead', []);
 
      var title;
+     var titleChanged;
 
      mod.directive(
          'viewTitle',
@@ -24,6 +25,7 @@
                              return iElement.text();
                          },
                          function (newTitle) {
+                             titleChanged = true;
                              $rootScope.viewTitle = title = newTitle;
                          }
                      );
@@ -33,10 +35,11 @@
                              title = undefined;
                              // Wait until next digest cycle do delete viewTitle
                              $timeout(function() {
-                                 if(!title) {
+                                 if(!title && !titleChanged) {
                                      // No other view-title has reassigned title.
                                      delete $rootScope.viewTitle;
                                  }
+                                 titleChanged = false;
                              });
                          }
                      );


### PR DESCRIPTION
There is an issue with Angular 1.5 with UI Router causing title to disappear even if new one is set. It is caused by how `$destroy` event is processed: after new directives has been created.

Simple check if the title has been updated is enough to work reliably.
